### PR TITLE
Disable other themes when loading stimmung-themes

### DIFF
--- a/stimmung-themes.el
+++ b/stimmung-themes.el
@@ -44,25 +44,19 @@
 ;;; Theme loading/toggle inspired/sourced from the fantastic `protesilaos/modus-themes'
 
 ;;;###autoload
-(defun stimmung-themes--toggle-prompt ()
-  "Helper for `stimmung-themes-toggle'."
-  (let ((theme (intern (completing-read "Load Stimmung theme: "
-                           '(stimmung-themes-light stimmung-themes-dark) nil t))))
-	(pcase theme
-	  ('stimmung-themes-light (load-theme 'stimmung-themes-light t))
-	  ('stimmung-themes-dark  (load-theme 'stimmung-themes-dark  t)))))
-
-;;;###autoload
 (defun stimmung-themes-toggle ()
   "Toggle between the dark and light version of `stimming-themes'.
 Prompt the user for which to pick in case none is enabled.
 Currently assumes the themes is loaded, which might be an issue.
 Inspired by modus-themes."
   (interactive)
-  (pcase (car custom-enabled-themes)
-	('stimmung-themes-light (load-theme 'stimmung-themes-dark  t))
-	('stimmung-themes-dark  (load-theme 'stimmung-themes-light t))
-	(_ (stimmung-themes--toggle-prompt))))
+  (let ((theme (pcase (car custom-enabled-themes)
+                 ('stimmung-themes-light 'stimmung-themes-dark)
+                 ('stimmung-themes-dark  'stimmung-themes-light)
+                 (_ (intern (completing-read "Load Stimmung theme: "
+                                '(stimmung-themes-light stimmung-themes-dark) nil t))))))
+    (mapc #'disable-theme custom-enabled-themes)
+    (load-theme theme t)))
 
 (provide 'stimmung-themes)
 


### PR DESCRIPTION
This is something I've noticed today while switching from a different theme to `stimmung-themes-light`.  The commit message hopefully explains the problem:

> When the user made their choice after invoking stimmung-themes-toggle, we should first disable all other themes before enabling the selection. The reason for that is that custom-enabled-themes holds a list of themes; i.e., multiple may be active at the same time.  This can look quite confusing when mixing e.g. a dark and a light theme, possibly leading to unreadable text.

The file mentions the modus themes as inspiration for the code; I double-checked and `modus-themes-toggle` does also disable all other themes before loading, so it's probably safe.

Along the way, I (imo) simplified the implementation somewhat, compressing everything down into one function.  If you don't agree, I can of course remove that part!