### PR TITLE
Add persp face

### DIFF
--- a/stimmung-themes-dark-theme.el
+++ b/stimmung-themes-dark-theme.el
@@ -273,7 +273,8 @@
    `(doom-modeline-evil-visual-state  ((t (:foreground ,fg1))))
    `(doom-modeline-evil-normal-state  ((t (:foreground ,fg1))))
    `(doom-modeline-evil-emacs-state   ((t (:foreground ,red :italic nil))))
-   
+   `(doom-modeline-buffer-minor-mode  ((t (:background ,bg5))))
+
    ;; dired
    `(dired-directory  ((t (:foreground ,fg1 :bold t))))
    `(dired-ignored    ((t (:foreground ,fg1))))

--- a/stimmung-themes-dark-theme.el
+++ b/stimmung-themes-dark-theme.el
@@ -536,6 +536,9 @@
    `(tab-line-tab-inactive				((t (:background ,bg1 :foreground ,fg5 :box (:line-width 1 :color ,fg2 :style nil)))))
    `(tab-line-tab-inactive-alternate	((t (:background ,bg1 :foreground ,fg4 :box (:line-width 1 :color ,fg2 :style nil)))))
 
+   ;; perspective
+   `(persp-selected-face ((t (:bold t))))
+
    ;; LaTeX
    `(font-latex-sectioning-0-face ((t (:bold t))))
    `(font-latex-sectioning-1-face ((t (:bold t))))

--- a/stimmung-themes-light-theme.el
+++ b/stimmung-themes-light-theme.el
@@ -534,6 +534,9 @@
    `(tab-line-tab-inactive				((t (:background ,bg1 :foreground ,fg5 :box (:line-width 1 :color ,fg2 :style nil)))))
    `(tab-line-tab-inactive-alternate	((t (:background ,bg1 :foreground ,fg4 :box (:line-width 1 :color ,fg2 :style nil)))))
 
+   ;; perspective
+   `(persp-selected-face ((t (:bold t))))
+
    ;; LaTeX
    `(font-latex-sectioning-0-face ((t (:bold t))))
    `(font-latex-sectioning-1-face ((t (:bold t))))


### PR DESCRIPTION
Adds (only) face for `perspective.el`, a package I'm quite fond of.

This also adds the common background to face `doom-modeline-buffer-minor-mode` but it's just a suggestion.

# Screenshot
![image](https://user-images.githubusercontent.com/12915439/162619872-c8ef9202-2dc0-4c62-bc7c-0732d8e5e281.png)
