### PR TITLE
Fix `diff-hl` highlighting

### DIFF
--- a/stimmung-themes-dark-theme.el
+++ b/stimmung-themes-dark-theme.el
@@ -442,12 +442,12 @@
    `(magit-section-highlight      ((t (:background ,bg3))))
 
    ;; diff-hl
-   `(diff-hl-insert         ((t (:foreground ,ok  :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-delete         ((t (:foreground ,red :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-change         ((t (:foreground ,fg1  :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-ignore         ((t (:foreground ,fg1  :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-margin-ignore  ((t (:foreground ,fg1  :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-margin-unknown ((t (:foreground ,fg1  :background ,bg1 :bold nil :italic nil))))
+   `(diff-hl-insert         ((t (:foreground ,fg1 :background ,ok :bold nil :italic nil))))
+   `(diff-hl-delete         ((t (:foreground ,fg1 :background ,red :bold nil :italic nil))))
+   `(diff-hl-change         ((t (:foreground ,fg1 :background ,search :bold nil :italic nil))))
+   `(diff-hl-ignore         ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
+   `(diff-hl-margin-ignore  ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
+   `(diff-hl-margin-unknown ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
 
    ;; help
    `(help-key-binding ((t (:foreground ,fg1 :background ,bg5 :box (:line-width 1 :color ,fg5)))))

--- a/stimmung-themes-light-theme.el
+++ b/stimmung-themes-light-theme.el
@@ -440,12 +440,12 @@
    `(magit-section-highlight      ((t (:background ,bg3))))
 
    ;; diff-hl
-   `(diff-hl-insert         ((t (:foreground ,ok  :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-delete         ((t (:foreground ,red :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-change         ((t (:foreground ,fg1  :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-ignore         ((t (:foreground ,fg1  :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-margin-ignore  ((t (:foreground ,fg1  :background ,bg1 :bold nil :italic nil))))
-   `(diff-hl-margin-unknown ((t (:foreground ,fg1  :background ,bg1 :bold nil :italic nil))))
+   `(diff-hl-insert         ((t (:foreground ,fg1 :background ,ok :bold nil :italic nil))))
+   `(diff-hl-delete         ((t (:foreground ,fg1 :background ,red :bold nil :italic nil))))
+   `(diff-hl-change         ((t (:foreground ,fg1 :background ,search :bold nil :italic nil))))
+   `(diff-hl-ignore         ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
+   `(diff-hl-margin-ignore  ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
+   `(diff-hl-margin-unknown ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
 
    ;; help
    `(help-key-binding ((t (:foreground ,fg1 :background ,bg5 :box (:line-width 1 :color ,fg5)))))


### PR DESCRIPTION
Hi again!  Still fiddling with `diredfl`, but this is a little thing I noticed along the way.

#### Commit Summary

##### [Fix diff-hl highlighting](https://github.com/motform/stimmung-themes/commit/0e6f201f314e961d484425bab670bf495507de1b)

In diff-hl mode, the margin faces diff-hl-margin-{insert,delete,change} inherit everything from the "normal" faces, except that they solely utilise the background colour to the margin indicator.  If this is just pure white, the user doesn't get any information as to the current status of the repo.  Since this may well be achieved by disabling diff-hl-margin-mode, set appropriate background colours by default.

#### Comparison

| Before (yes, really!)                                                                                                                     | After                                                                                                                                     |
|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
| ![2022-05-10-181341_554x343_scrot](https://user-images.githubusercontent.com/50166980/167783979-1fc92c6f-31b6-4336-966c-0c10635918f6.png) | ![2022-05-10-181441_545x364_scrot](https://user-images.githubusercontent.com/50166980/167784013-7721c284-ec63-43a0-9561-b20f9fecbcec.png) |

Just now I notice that the second "modified" should be a "deleted" of course.  Oh well, you know what I mean :)

I tried making this shades of grey, but it kind of didn't look right.  The grey has to be pretty dark, almost black, for the user to be able to see it.  At the end I settled on the colours that were already there for added and removed, as well as `search` for modified.  I think it fits pretty well.  