### PR TITLE
Add git gutter colors

### DIFF
--- a/stimmung-themes-dark-theme.el
+++ b/stimmung-themes-dark-theme.el
@@ -464,6 +464,13 @@ ITALIC? and BOLD? control font variant."
 	 `(diff-hl-margin-ignore  ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
 	 `(diff-hl-margin-unknown ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
 
+	 ;; git-gutter-fringe
+	 `(git-gutter-fr:added    ((t (:foreground ,ok :bold nil :italic nil))))
+	 `(git-gutter-fr:deleted  ((t (:foreground ,red :bold nil :italic nil))))
+	 `(git-gutter-fr:modified ((t (:foreground ,search :bold nil :italic nil))))
+	 `(git-gutter:added       ((t (:foreground ,ok :bold nil :italic nil))))
+	 `(git-gutter:deleted     ((t (:foreground ,red :bold nil :italic nil))))
+	 `(git-gutter:modified    ((t (:foreground ,search :bold nil :italic nil))))
 
 	 ;; help
 	 `(help-key-binding ((t (:foreground ,fg1 :background ,bg5 :box (:line-width 1 :color ,fg5)))))

--- a/stimmung-themes-light-theme.el
+++ b/stimmung-themes-light-theme.el
@@ -463,6 +463,14 @@ ITALIC? and BOLD? control font variant."
 	 `(diff-hl-margin-ignore  ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
 	 `(diff-hl-margin-unknown ((t (:foreground ,fg1 :background ,bg1 :bold nil :italic nil))))
 
+	 ;; git-gutter-fringe
+	 `(git-gutter-fr:added    ((t (:foreground ,ok :bold nil :italic nil))))
+	 `(git-gutter-fr:deleted  ((t (:foreground ,red :bold nil :italic nil))))
+	 `(git-gutter-fr:modified ((t (:foreground ,search :bold nil :italic nil))))
+	 `(git-gutter:added       ((t (:foreground ,ok :bold nil :italic nil))))
+	 `(git-gutter:deleted     ((t (:foreground ,red :bold nil :italic nil))))
+	 `(git-gutter:modified    ((t (:foreground ,search :bold nil :italic nil))))
+
 	 ;; help
 	 `(help-key-binding ((t (:foreground ,fg1 :background ,bg5 :box (:line-width 1 :color ,fg5)))))
 


### PR DESCRIPTION
Uses search, red and ok colors for modified, deleted and added
respectively. search is used instead of warning as it stands out less
against the default highlight colors.