### PR TITLE
feat: enable builtin `toggle-theme` to switch between dark/light

### DIFF
--- a/stimmung-themes-dark-theme.el
+++ b/stimmung-themes-dark-theme.el
@@ -43,7 +43,10 @@
 (require 'stimmung-themes)
 
 (deftheme stimmung-themes-dark
-  "A dark theme tuned to inner harmonies.")
+  "A dark theme tuned to inner harmonies."
+  :family 'stimmung-themes
+  :kind 'color-scheme
+  :background-mode 'dark)
 
 (let ((bg1 "#1E1E1E")
       (bg2 "#404040")

--- a/stimmung-themes-light-theme.el
+++ b/stimmung-themes-light-theme.el
@@ -43,7 +43,10 @@
 (require 'stimmung-themes)
 
 (deftheme stimmung-themes-light
-  "A light theme tuned to inner harmonies.")
+  "A light theme tuned to inner harmonies."
+  :family 'stimmung-themes
+  :kind 'color-scheme
+  :background-mode 'light)
 
 (let ((bg1 "white")
 	    (bg2 "gray95")


### PR DESCRIPTION
Emacs has its own function `toggle-theme`, an alias of `theme-choose-variant`, which requires a theme to have certain attributes in order to know which themes belong together.  This PR adds those attributes, enabling the function `toggle-theme` to switch between light and dark.

The [elisp docs on custom themes](https://www.gnu.org/software/emacs/manual/html_node/elisp/Custom-Themes.html) show which attributes are required and the last two paragraphs of the [Emacs docs on custom themes](https://www.gnu.org/software/emacs/manual/html_node/emacs/Custom-Themes.html) explain the user interface. It's nice to have one function to toggle dark/light that doesn't care which theme family is active.

The function `stimmung-themes-toggle` could then _potentially_ be deprecated, made an alias of `theme-choose-variant` or somthing, but that would require some discussion, so it's not part of this PR.